### PR TITLE
Implemented workaround to prevent hanging of manhattan plot for gene …

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
         "react-scroll-to-top": "^0.2.4",
         "react-select": "^3.1.0",
         "react-slidedown": "^2.4.5",
+        "react-switch": "^6.0.0",
         "react-table": "^7.3.2",
         "react-typing-effect": "^2.0.3",
         "react-virtualized": "^9.21.2",

--- a/client/src/Components/Biomarker/Biomarker.js
+++ b/client/src/Components/Biomarker/Biomarker.js
@@ -188,9 +188,16 @@ const Biomarker = (props) => {
                             <span className='link'> {`${TitleCase(compound)}`} </span>
                             <span> and </span>
                             <span className='link'> {`${gene.toUpperCase()}`} </span>
-                            <span> in </span>
-                            <span className='link'> {`${TitleCase(tissue)}`} </span>
-                            <span> tissue </span>
+                            {
+                                tissue ?
+                                <React.Fragment>
+                                    <span> in </span>
+                                    <span className='link'> {`${TitleCase(tissue)}`} </span>
+                                    <span> tissue </span>
+                                </React.Fragment>
+                                :
+                                ''
+                            }
                         </span>
                     </div>
                     <div className='wrapper'>
@@ -212,7 +219,7 @@ const Biomarker = (props) => {
                                 {
                                     display === 'manhattan_plot' &&
                                     <Element className="section" name="manhattan_plot">
-                                        <ManhattanPlotContainer compound={compound} tissue={tissue} />
+                                        <ManhattanPlotContainer biomarker={transformedGeneData[0]} compound={compound} tissue={tissue} />
                                     </Element>
                                 }
                                 {

--- a/client/src/queries/gene_compound.js
+++ b/client/src/queries/gene_compound.js
@@ -71,14 +71,43 @@ const getGeneCompoundTissueDatasetQuery = gql`
 `;
 
 /**
- * Query used to get data for the Manhattan plot on Biomarker page.
+ * Query used to get data for the tissue specific Manhattan plot on Biomarker page.
  * @param compoundId/compoundName - identifier for the compound.
  * @param tissueId/tissueName = identifier for the tissue.
- * mDataType is specified as "rna" to filter the experiment data rna data type. 
+ * @param mDataType - selected molecular data type
  */
-const getManhattanPlotDataQuery = gql`
+const getTissueSpecificManhattanPlotDataQuery = gql`
     query getManhattanPlotDataQuery($compoundId: Int, $tissueId: Int, $compoundName: String, $tissueName: String, $mDataType: String) {
-        gene_compound_tissue_dataset(compoundId: $compoundId, tissueId: $tissueId, compoundName: $compoundName, tissueName: $tissueName, mDataType: $mDataType, all: true) {
+        gene_compound_tissue_dataset_biomarker(compoundId: $compoundId, tissueId: $tissueId, compoundName: $compoundName, tissueName: $tissueName, mDataType: $mDataType, all: true) {
+            gene {
+                id
+                name
+                annotation {
+                    symbol
+                    chr
+                    gene_seq_start
+                    gene_seq_end
+                }
+            }
+            dataset {
+                id
+                name
+            }
+            fdr_analytic
+            fdr_permutation
+            mDataType
+        }
+    }
+`;
+
+/**
+ * Query used to get data for the pan cancer Manhattan plot on Biomarker page. (without specified tissue)
+ * @param compoundId/compoundName - identifier for the compound.
+ * @param mDataType - selected molecular data type
+ */
+const getPanCancerManhattanPlotDataQuery = gql`
+    query getPanCancerManhattanPlotDataQuery($compoundId: Int, $compoundName: String, $mDataType: String) {
+        gene_compound_dataset_biomarker(compoundId: $compoundId, compoundName: $compoundName, mDataType: $mDataType, all: true) {
             gene {
                 id
                 name
@@ -103,5 +132,6 @@ const getManhattanPlotDataQuery = gql`
 export {
     getGeneCompoundDatasetQuery,
     getGeneCompoundTissueDatasetQuery,
-    getManhattanPlotDataQuery
+    getTissueSpecificManhattanPlotDataQuery,
+    getPanCancerManhattanPlotDataQuery
 };

--- a/graphql/schema/root_query.js
+++ b/graphql/schema/root_query.js
@@ -96,7 +96,8 @@ const RootQuery = `type RootQuery {
     gene_compound_tissue(geneId: Int, compoundId: Int, tissueId: Int, page: Int, per_page: Int, all: Boolean): [GeneCompoundTissue!]!
     gene_compound_dataset(geneId: Int, compoundId: Int, page: Int, per_page: Int, all: Boolean): [GeneCompoundDataset!]!
     gene_compound_tissue_dataset(geneId: Int, compoundId: Int, tissueId: Int, geneName: String, compoundName: String, tissueName: String, mDataType: String, page: Int, per_page: Int, all: Boolean): [GeneCompoundTissueDataset!]!
-
+    gene_compound_dataset_biomarker(compoundId: Int, compoundName: String, mDataType: String, page: Int, per_page: Int, all: Boolean): [GeneCompoundDataset!]!
+    gene_compound_tissue_dataset_biomarker(compoundId: Int, tissueId: Int, compoundName: String, tissueName: String, mDataType: String, page: Int, per_page: Int, all: Boolean): [GeneCompoundTissueDataset!]!
 
     """
         Root Queries for targets.


### PR DESCRIPTION
Implemented work around for slow query to fetch manhattan plot data for gene + compound biomarker page.

1. Implemented GraphQL API resolvers (gene_compound_dataset_biomarker and gene_compound_tissue_dataset_biomarker) for the manhattan plot data.
2. Implemented high res / low res option switch.
3. Removes tissue from the page title if only gene and compound are selected.