### PR TITLE
added ensembl descriptions to the individual gene page

### DIFF
--- a/client/src/Components/IndividualComponents/IndivCompounds/Tables/AnnotatedTargetsTable.js
+++ b/client/src/Components/IndividualComponents/IndivCompounds/Tables/AnnotatedTargetsTable.js
@@ -43,6 +43,13 @@ const AnnotatedTargetsTable = (props) => {
         {
             Header: 'Gene ID',
             accessor: 'gene_name',
+            Cell: (item) => {
+                return item.value.startsWith("ENSG") ?
+                    <a href={`http://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${item.value}`} target="_blank">
+                        {item.value}
+                    </a>
+                    : <span>{item.value}</span>
+            }
         }
     ];
 
@@ -79,8 +86,8 @@ const AnnotatedTargetsTable = (props) => {
                                 </p>
                             </h4>
                             {
-                                tableData.data.length > 0 ? 
-                                    tableData.ready && 
+                                tableData.data.length > 0 ?
+                                    tableData.ready &&
                                     <React.Fragment>
                                         <div className='download-button'>
                                             <DownloadButton

--- a/client/src/Components/IndividualComponents/IndivDatasets/Tables/CellLineSummaryTable.js
+++ b/client/src/Components/IndividualComponents/IndivDatasets/Tables/CellLineSummaryTable.js
@@ -34,7 +34,7 @@ const CellLineSummaryTable = (props) => {
 
     const { loading } = useQuery(getDatasetTestedCellsQuery, {
         variables: { datasetId: dataset.id },
-        fetchPolicy: "network-only",
+        fetchPolicy: "cache-first",
         onCompleted: (res) => {
             let data = res.dataset_type[0];
             data = { id : data.dataset.id, name: data.dataset.name, cells_tested : data.cells_tested}

--- a/client/src/Components/IndividualComponents/IndivDatasets/Tables/CompoundsSummaryTable.js
+++ b/client/src/Components/IndividualComponents/IndivDatasets/Tables/CompoundsSummaryTable.js
@@ -30,10 +30,10 @@ const CompoundsSummaryTable = (props) => {
           Cell: (item) => <a href={`/compounds/${item.cell.row.original.uid}`}>{item.value}</a>
         }
     ];
-    
+
     const { loading } = useQuery( getDatasetTestedCompoundsQuery, {
         variables: { datasetId: dataset.id },
-        fetchPolicy: "network-only",
+        fetchPolicy: "cache-first",
         onCompleted: (res) => {
             let data = res.dataset_type[0];
             data = { id : data.dataset.id, name: data.dataset.name, compounds_tested : data.compounds_tested}

--- a/client/src/Components/IndividualComponents/IndivGenes/Description.js
+++ b/client/src/Components/IndividualComponents/IndivGenes/Description.js
@@ -72,7 +72,7 @@ const Description = (props) => {
                 .then(
                     (result) => {
                         setIsLoaded(true);
-                        setGeneDes(result);
+                        setGeneDes(result.description? result: '');
                     },
                     (error) => {
                         setIsLoaded(true);
@@ -84,7 +84,8 @@ const Description = (props) => {
                 .then(
                     (result) => {
                         setLoaded(true);
-                        setGeneSyn(result.filter(ref => ref.synonyms.length ).map(ref => ref.synonyms));
+                        console.log(result)
+                        setGeneSyn( result[0]? result.filter(ref => ref.synonyms.length).map(ref => ref.synonyms):[]);
                     },
                     (error) => {
                         setLoaded(true);
@@ -93,7 +94,6 @@ const Description = (props) => {
                 )
         }
     }, [gene.annotation])
-    console.log(Object.keys(geneDes).length, geneDes, geneSyn.length, geneSyn)
     return (
         <React.Fragment>
             {

--- a/client/src/Components/IndividualComponents/IndivGenes/Description.js
+++ b/client/src/Components/IndividualComponents/IndivGenes/Description.js
@@ -1,0 +1,154 @@
+/* eslint-disable radix */
+/* eslint-disable no-nested-ternary */
+import React, { useState, useEffect } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import PropTypes from 'prop-types';
+import { getGeneTargetCountCompoundsByDataset} from '../../../queries/target';
+import dataset_colors from '../../../styles/dataset_colors';
+import Loading from '../../UtilComponents/Loading';
+import Error from '../../UtilComponents/Error';
+import PlotsWrapper from '../../../styles/PlotsWrapper';
+import DatasetHorizontalPlot from '../../Plots/DatasetHorizontalPlot';
+import { Element } from 'react-scroll';
+
+/**
+ * A helper function that processes data from the ensembl API to extract gene description and location
+ * @param {Object} geneDes - object of gene descriptions for a given gene ensembl id returned by the API
+ * @returns - object of gene information, including gene description and location
+ * @example
+ * [{description: "BRCA2 DNA repair associated", location: ""}]
+ */
+const generateDescriptionData = (gene) => {
+    const des = gene["description"]
+    const hgncId = des.substring(des.indexOf("HGNC:"), des.length -1);
+    const hgncLink = `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${hgncId}`;
+    // location information
+    const strand = gene["strand"] === 1 ? "forward strand" : "reverse strand";
+    const location = gene["seq_region_name"]+":"+gene["start"]+"-"+gene["end"];
+    const locLink = `http://useast.ensembl.org/Homo_sapiens/Location/View?db=core;g=${hgncId};r=${location}`
+    const returnObj = {
+        des: (
+            <div className="text">
+                { des.substring(0, des.indexOf("HGNC:"))}
+                <a href={hgncLink} target="_blank">{hgncId}</a>
+                {des.substring(des.length-1)}
+            </div>
+            ),
+        loc: (
+            <div className="text">
+                <a href={locLink} target="_blank">{ "Chromosome "+ location + " "}</a>
+                {strand + "."}
+            </div>
+        )
+    }
+    return returnObj;
+};
+/**
+ * Section that displays gene description on individual gene page
+ *
+ * @component
+ * @example
+ *
+ * returns (
+ *   <Description/>
+ * )
+ */
+const Description = (props) => {
+    const { gene } = props;
+
+    const xrefLink = `https://rest.ensembl.org/xrefs/id/${gene.name}?content-type=application/json`;
+    const descLink = `https://rest.ensembl.org/lookup/id/${gene.name}?content-type=application/json`;
+
+    const [error, setError] = useState(null);
+    const [err, setErr] = useState(null);
+    const [isLoaded, setIsLoaded] = useState(false);
+    const [geneDes, setGeneDes] = useState([]);
+    const [loaded, setLoaded] = useState(false);
+    const [geneSyn, setGeneSyn] = useState([]);
+    useEffect(() => {
+        if(gene.annotation) {
+            fetch(descLink)
+                .then(res => res.json())
+                .then(
+                    (result) => {
+                        setIsLoaded(true);
+                        setGeneDes(result);
+                    },
+                    (error) => {
+                        setIsLoaded(true);
+                        setError(error);
+                    }
+                )
+            fetch(xrefLink)
+                .then(res => res.json())
+                .then(
+                    (result) => {
+                        setLoaded(true);
+                        setGeneSyn(result.filter(ref => ref.synonyms.length ).map(ref => ref.synonyms));
+                    },
+                    (error) => {
+                        setLoaded(true);
+                        setError(err);
+                    }
+                )
+        }
+    }, [gene.annotation])
+    console.log(Object.keys(geneDes).length, geneDes, geneSyn.length, geneSyn)
+    return (
+        <React.Fragment>
+            {
+                !isLoaded || !loaded ? <Loading />
+                :
+                error || err ? <Error />
+                :
+                    <React.Fragment>
+                        {Object.keys(geneDes).length ?
+                            (
+                                <Element className="section">
+                                    <div className='section-title'>Description</div>
+                                    {geneDes["description"].length ?
+                                        (<div className="text">
+                                            {generateDescriptionData(geneDes)["des"]}
+                                        </div>)
+                                        : <h6>N/A</h6>}
+                                </Element>
+                            ): ''
+                            }
+                        {
+                            geneSyn.length ?
+                            <Element className="section">
+                                <div className='section-title'>Synonyms</div>
+                                {
+                                    geneSyn.length ?
+                                        <div className="text">{ geneSyn[0].join(", ")}</div>
+                                        : <h6>N/A</h6>
+                                }
+                            </Element>
+                            :''
+                        }
+                        {Object.keys(geneDes).length ?
+                            <Element className="section">
+                                <div className='section-title'>Location</div>
+                                {geneDes["description"].length ?
+                                    (<div className="text">
+                                        {generateDescriptionData(geneDes)["loc"]}
+                                    </div>)
+                                    : <h6>N/A</h6>}
+                            </Element>
+                            :''
+                        }
+                    </React.Fragment>
+
+            }
+        </React.Fragment>
+    );
+};
+
+Description.propTypes = {
+    gene: PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+    }).isRequired,
+};
+
+export default Description;

--- a/client/src/Components/IndividualComponents/IndivGenes/IndivGenes.js
+++ b/client/src/Components/IndividualComponents/IndivGenes/IndivGenes.js
@@ -13,6 +13,7 @@ import Table from '../../UtilComponents/Table/Table';
 import PlotSection from './PlotSection';
 import CompoundsSummaryTable from './Tables/CompoundsSummaryTable';
 import TopDrugsTable from './Tables/TopDrugsTable';
+import Description from './Description'
 
 import {
   StyledIndivPage,
@@ -24,10 +25,12 @@ const SYNONYM_COLUMNS = [
   {
     Header: 'Ensembl Gene ID',
     accessor: 'ensemblId',
+    center: true,
   },
   {
     Header: 'Genecard',
     accessor: 'geneCard',
+    center: true,
   },
 ];
 
@@ -36,7 +39,8 @@ const LINK_COLUMNS = [
 ];
 
 const SIDE_LINKS = [
-  { label: 'Synonyms and Plots', name: 'synonyms' },
+  { label: 'Synonyms and Links', name: 'synonyms' },
+  { label: 'Plots', name: 'plots' },
   { label: 'Drug Summary', name: 'drugsSummary' },
   { label: 'Top Drugs', name: 'topDrugs' }
 ];
@@ -52,11 +56,11 @@ const formatTableLinks = (data) => [
         <div style={{ textAlign: 'center' }}> {data.name} </div>
       </a>
     ),
-    geneCard: (
+    geneCard: data.annotation.symbol !== "N/A" ? (
       <a href={`https://www.genecards.org/cgi-bin/carddisp.pl?gene=${data.name}`} target="_blank">
         <div style={{ textAlign: 'center' }}> {data.annotation.symbol} </div>
       </a>
-    ),
+    ) : 'N/A',
   },
 ];
 
@@ -148,20 +152,18 @@ const IndivGenes = (props) => {
                           display === 'synonyms' &&
                           <React.Fragment>
                             <Element className="section" name="synonyms">
-                              <div className='section-title'>Synonyms</div>
+                              {/*<div className='section-title'>Synonyms</div>*/}
                               <Table columns={SYNONYM_COLUMNS} data={gene.data.synonyms} disablePagination />
                             </Element>
-                            {
-                              gene.data.length ?
-                                  (
-                                      <Element className='section' name="plots">
-                                        <div className='section-title'>Plots</div>
-                                        <PlotSection gene={gene.data} />
-                                      </Element>
-                                  )
-                                  :''
-                            }
+                            <Description gene={gene.data} />
                           </React.Fragment>
+                        }
+                        {
+                          display === 'plots' &&
+                          <Element className='section' name="plots">
+                            <div className='section-title'>Plots</div>
+                              <PlotSection gene={gene.data} />
+                          </Element>
                         }
                         {
                           display === 'drugsSummary' &&

--- a/client/src/Components/IndividualComponents/IndivGenes/IndivGenes.js
+++ b/client/src/Components/IndividualComponents/IndivGenes/IndivGenes.js
@@ -152,7 +152,6 @@ const IndivGenes = (props) => {
                           display === 'synonyms' &&
                           <React.Fragment>
                             <Element className="section" name="synonyms">
-                              {/*<div className='section-title'>Synonyms</div>*/}
                               <Table columns={SYNONYM_COLUMNS} data={gene.data.synonyms} disablePagination />
                             </Element>
                             {
@@ -160,7 +159,6 @@ const IndivGenes = (props) => {
                                   <Description gene={gene.data} />
                                   : ''
                             }
-
                           </React.Fragment>
                         }
                         {

--- a/client/src/Components/IndividualComponents/IndivGenes/IndivGenes.js
+++ b/client/src/Components/IndividualComponents/IndivGenes/IndivGenes.js
@@ -155,7 +155,12 @@ const IndivGenes = (props) => {
                               {/*<div className='section-title'>Synonyms</div>*/}
                               <Table columns={SYNONYM_COLUMNS} data={gene.data.synonyms} disablePagination />
                             </Element>
-                            <Description gene={gene.data} />
+                            {
+                              gene.data.name.startsWith("ENSG") ?
+                                  <Description gene={gene.data} />
+                                  : ''
+                            }
+
                           </React.Fragment>
                         }
                         {

--- a/client/src/Components/IndividualComponents/IndivGenes/PlotSection.js
+++ b/client/src/Components/IndividualComponents/IndivGenes/PlotSection.js
@@ -65,14 +65,17 @@ const PlotSection = (props) => {
           :
           error ? <Error />
             :
-            <PlotsWrapper single={true}>
-              <DatasetHorizontalPlot
-                plotId='gene_compound_dataset_plot'
-                data={data}
-                xaxis="# of compounds"
-                title={`Number of compounds targeting ${gene.annotation.symbol} (per dataset)`}
-              />
-            </PlotsWrapper>
+              data.length > 0 ? (
+                <PlotsWrapper single={true}>
+                  <DatasetHorizontalPlot
+                      plotId='gene_compound_dataset_plot'
+                      data={data}
+                      xaxis="# of compounds"
+                      title={`Number of compounds targeting ${gene.annotation.symbol} (per dataset)`}
+                  />
+                </PlotsWrapper>
+              ) :
+                  <h6>No data is available to plot.</h6>
       }
     </React.Fragment>
   );

--- a/client/src/Components/Plots/BarPlot.js
+++ b/client/src/Components/Plots/BarPlot.js
@@ -30,7 +30,7 @@ const parsePlotData = (data) => {
     y: [],
     type: 'bar',
     marker: {
-      color: ['#084081', '#0868ac', '#2b8cbe', '#4eb3d3', '#7bccc4', '#a8ddb5', '#ccebc5', '#e0f3db', '#eff8e4', '#f7fcf0'],
+      color: ['#084081', '#0868ac', '#2b8cbe', '#4eb3d3', '#7bccc4', '#a8ddb5', '#ccebc5', '#e0f3db', '#eef6c9', '#f7fcf0'],
     },
   }
   if (typeof data !== 'undefined') {

--- a/client/src/Components/SummaryComponents/Compounds/Compounds.js
+++ b/client/src/Components/SummaryComponents/Compounds/Compounds.js
@@ -29,7 +29,14 @@ const table_columns = [
   {
     Header: 'PubChem',
     accessor: 'pubchem',
-    Cell: (row) => (<a href={`${PUBCHEM_LINK}${row.value}`} target='_blank'>{row.value}</a>),
+    Cell: (item) => {
+      let pubchem = item.cell.row.original.pubchem;
+      return(pubchem.map((id, i) => (
+        <span key={i}>
+          <a href={`${PUBCHEM_LINK}${id}`}>{id}</a>{ i + 1 < pubchem.length ? ', ' : ''}
+        </span>)
+      ));
+    }
   },
   {
     Header: 'ChEMBL',
@@ -52,8 +59,9 @@ const getTableData = (data) => {
     table_data = data.compounds.map((value) => {
       const { name, annotation, id, uid } = value;
       const {
-        smiles, inchikey, pubchem, fda_status, chembl
+        smiles, inchikey, fda_status, chembl
       } = annotation;
+      const pubchem = annotation.pubchem ? annotation.pubchem.split("///") : null;
       return {
         id,
         name,

--- a/client/src/Components/SummaryComponents/Genes/GenesTable.js
+++ b/client/src/Components/SummaryComponents/Genes/GenesTable.js
@@ -57,7 +57,6 @@ const GenesTable = () => {
 
   const { loading } = useQuery(getGenesQuery, {
     onCompleted: (data) => {
-      console.log(data)
       setGenes(getTableData(data));
     },
     onError: (err) => {

--- a/client/src/styles/dataset_colors.js
+++ b/client/src/styles/dataset_colors.js
@@ -1,2 +1,2 @@
 // export default ['#08589e', '#2b8cbe', '#4eb3d3', '#7bccc4', '#a8ddb5', '#ccebc5', '#f0f9e8'];
-export default ['#084081', '#0868ac', '#2b8cbe', '#4eb3d3', '#7bccc4', '#a8ddb5', '#ccebc5', '#e0f3db', '#f7fcf0']
+export default ['#084081', '#0868ac', '#2b8cbe', '#4eb3d3', '#7bccc4', '#a8ddb5', '#ccebc5', '#e0f3db', '#eef6c9', '#f7fcf0']

--- a/graphql/schema/target.js
+++ b/graphql/schema/target.js
@@ -54,11 +54,11 @@ const compoundsGeneTargetType = `
 const geneTargetCompoundCountsType = `
     type GeneTargetCompoundCounts {
         """gene id in the database"""
-        gene_id: Int!
+        gene_id: Int
         """gene id in the database"""
-        gene_name: String!
+        gene_name: String
         """ array of datasets and the count of targeting compounds in each"""
-        targetsStat: [DatasetCompoundStat]!
+        targetsStat: [DatasetCompoundStat]
     }
 `;
 


### PR DESCRIPTION
- Collected gene descriptions using Ensembl api for a given gene, and put back plot to a separate section on the individual gene page, closes #84, #390
- Minor change on target api schema
- split pubchem ids with /// and fixed the links , closes #413 
- updated summary tables on individual dataset pages' fetch policy