### PR TITLE
Dose Response Curve Modifications

### DIFF
--- a/client/src/Components/Plots/DoseResponseCurve.js
+++ b/client/src/Components/Plots/DoseResponseCurve.js
@@ -36,8 +36,8 @@ const DoseResponseCurve = (props) => {
                     showline: true,
                     fixedrange: true,
                     range: [
-                        showScatter ? plotData.yMin : 0, 
-                        showScatter ? plotData.yMax + 5 : 100
+                        showScatter ? (plotData.yMin >=0 ? plotData.yMin >=0 : 0) : 0, 
+                        showScatter ? (plotData.yMax + 5 >= 100 ? plotData.yMax + 5 : 100) : 100
                     ]
                 },
                 hovermode: "closest",

--- a/client/src/Components/UtilComponents/Checkbox.js
+++ b/client/src/Components/UtilComponents/Checkbox.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import colors from '../../styles/colors';
@@ -62,7 +62,11 @@ const StyledCheckbox = styled.label`
         font-weight: bold;
     }
 `;
-
+/**
+ * Custom, styled checkbox component.
+ * @param {*} props 
+ * @returns 
+ */
 const Checkbox = (props) => {
     const { value, label, checked, color, onChange, disabled } = props;
     const [isChecked, setIsChecked] = useState(checked);
@@ -71,6 +75,12 @@ const Checkbox = (props) => {
         setIsChecked(!isChecked);
         onChange(e);
     };
+
+    // Auto-check/uncheck the checkbox when props.checked status is changed by external actions (dose response curve click.)
+    // This applies in Tissue vs Compound page where a dose response curves that shares a cell line can be highlighted by being clicked.
+    useEffect(() => {
+        setIsChecked(checked);
+    }, [checked])
 
     return(
         <StyledCheckbox color={color}>

--- a/client/src/utils/useExpIntersection.js
+++ b/client/src/utils/useExpIntersection.js
@@ -334,13 +334,14 @@ const useExpIntersection = () => {
     };
 
     /**
-     * Modify the plot traces on curve click.
+     * Modifies the plot traces on curve click (highlighted or unhighlighted)
+     * Check/uncheck highlighted/unhighlighted cell line checkbox.
      * Used in tissue vs compound page.
      * @param {*} e 
      */
     const onCurveClick = (e) => {
-        let cell = experiments.find(item => item.id === e.points[0].data.id).cell_line.name;
-        let expIds = experiments.filter(item => item.cell_line.name === cell).map(item => item.id);
+        let selectedCell = experiments.find(item => item.id === e.points[0].data.id).cell_line.name;
+        let expIds = experiments.filter(item => item.cell_line.name === selectedCell).map(item => item.id);
         let newTraces = plotData.traces.map(item => {
             if (item.curve && expIds.includes(item.id)) {
                 let newItem = { ...item };
@@ -349,6 +350,17 @@ const useExpIntersection = () => {
             }
             return item;
         });
+        // Check/uncheck cell line checkbox if a seleted cell line that belongs to clicked experiment curve.
+        let newCellLines = cellLines.map(item => {
+            if(item.name === selectedCell){
+                return {
+                    ...item,
+                    checked: !item.checked
+                }
+            }
+            return item;
+        });
+        setCellLines(newCellLines);
         setPlotData({
             ...plotData,
             traces: newTraces


### PR DESCRIPTION
1. Set minimum and maximum ranges in Y axis to always include 0-100. Closes Issue #420 
2. Update cell line checkbox checked status when a dose response curve is clicked on Tissue vs Compound page #421 